### PR TITLE
Implement season and catalog editor.

### DIFF
--- a/assets/js/saveeditor.js
+++ b/assets/js/saveeditor.js
@@ -236,6 +236,9 @@ function loadSave(){
 	document.getElementById("player_rank_exp_holder").value = SaveJson["server"]["PlayerRankExp"];
     document.getElementById("money_holder").value = SaveJson["server"]["Money"];
     document.getElementById("snail_holder").value = SaveJson["server"]["Shell"];
+	document.getElementById("season_id_holder").value = SaveJson["client"]["Plaza"]["UnlockedSeason"];
+	document.getElementById("season_catalog_level_holder").value = SaveJson["server"]["Season"]["CatalogLevel"];
+	document.getElementById("season_catalog_point_holder").value = SaveJson["server"]["Season"]["CatalogPoint"];
 
     var playerInfo = SaveJson["client"]["Common"]["Coordinates"];
     click_clickable_sett(getElementByRsdbId("player_playertype", playerInfo["ModelType"]));
@@ -724,6 +727,26 @@ async function load_options(){
         if(snail_holder.value > 999) snail_holder.value = 999;
         if(snail_holder.value < 0) snail_holder.value = 0;
         SaveEdits["default_edits"]["snails"] = snail_holder.value;
+    });
+	$('.season_id_holder').on("propertychange change click keyup input paste", function(event){
+        var season_id_holder = event.target;
+		var current_season = 3; // Fresh Season 2023
+        if(season_id_holder.value > current_season) season_id_holder.value = current_season;
+        if(season_id_holder.value < 0) season_id_holder.value = 0;
+        SaveEdits["default_edits"]["current_season_id"] = season_id_holder.value;
+		SaveEdits["default_edits"]["unlocked_season_id"] = season_id_holder.value;
+    });
+	$('.season_catalog_level_holder').on("propertychange change click keyup input paste", function(event){
+        var catalog_level_holder = event.target;
+        if(catalog_level_holder.value > 100) catalog_level_holder.value = 100;
+        if(catalog_level_holder.value < 0) catalog_level_holder.value = 0;
+        SaveEdits["default_edits"]["season_catalog_level"] = catalog_level_holder.value;
+    });
+	$('.season_catalog_point_holder').on("propertychange change click keyup input paste", function(event){
+        var catalog_point_holder = event.target;
+        if(catalog_point_holder.value > 9500) catalog_point_holder.value = 9500;
+        if(catalog_point_holder.value < 0) catalog_point_holder.value = 0;
+        SaveEdits["default_edits"]["season_catalog_point"] = catalog_point_holder.value;
     });
     $('.player_playertype').click( function(event){
         click_clickable_sett(event.target);

--- a/assets/js/saveeditor.js
+++ b/assets/js/saveeditor.js
@@ -728,13 +728,10 @@ async function load_options(){
         if(snail_holder.value < 0) snail_holder.value = 0;
         SaveEdits["default_edits"]["snails"] = snail_holder.value;
     });
-	$('.season_id_holder').on("propertychange change click keyup input paste", function(event){
-        var season_id_holder = event.target;
-		var current_season = 3; // Fresh Season 2023
-        if(season_id_holder.value > current_season) season_id_holder.value = current_season;
-        if(season_id_holder.value < 0) season_id_holder.value = 0;
-        SaveEdits["default_edits"]["current_season_id"] = season_id_holder.value;
-		SaveEdits["default_edits"]["unlocked_season_id"] = season_id_holder.value;
+	$('#season_id_holder').on("change", function(event){
+        var season_id_holder = $(this).find("option:selected").prop("value");
+        SaveEdits["default_edits"]["current_season_id"] = season_id_holder;
+        SaveEdits["default_edits"]["unlocked_season_id"] = season_id_holder;
     });
 	$('.season_catalog_level_holder').on("propertychange change click keyup input paste", function(event){
         var catalog_level_holder = event.target;

--- a/assets/js/saveeditor.js
+++ b/assets/js/saveeditor.js
@@ -236,9 +236,9 @@ function loadSave(){
 	document.getElementById("player_rank_exp_holder").value = SaveJson["server"]["PlayerRankExp"];
     document.getElementById("money_holder").value = SaveJson["server"]["Money"];
     document.getElementById("snail_holder").value = SaveJson["server"]["Shell"];
-	document.getElementById("season_id_holder").value = SaveJson["client"]["Plaza"]["UnlockedSeason"];
-	document.getElementById("season_catalog_level_holder").value = SaveJson["server"]["Season"]["CatalogLevel"];
-	document.getElementById("season_catalog_point_holder").value = SaveJson["server"]["Season"]["CatalogPoint"];
+    document.getElementById("season_id_holder").value = SaveJson["client"]["Plaza"]["UnlockedSeason"];
+    document.getElementById("season_catalog_level_holder").value = SaveJson["server"]["Season"]["CatalogLevel"];
+    document.getElementById("season_catalog_point_holder").value = SaveJson["server"]["Season"]["CatalogPoint"];
 
     var playerInfo = SaveJson["client"]["Common"]["Coordinates"];
     click_clickable_sett(getElementByRsdbId("player_playertype", playerInfo["ModelType"]));

--- a/saveeditor.html
+++ b/saveeditor.html
@@ -90,8 +90,19 @@
             <label class="fw-bold" for="snail_holder">Snails:</label>
             <input class="form-control snail_holder d-inline-block w-auto" type="number" id="snail_holder" min="0" max="999" value="0"/>
             <br><br><br>
-            <label style="color:black" class="fw-bold" for="season_id_holder">Season:</label>
-            <input class="form-control season_id_holder d-inline-block w-auto" type="number" id="season_id_holder" min="0" max="999" value="0"/>
+            <form>
+              <div class="form-group row">
+                <label for="season_id_holder" class="col-sm-1 col-form-label fw-bold">Season:</label>
+                <div class="col-sm-3">
+                  <select id="season_id_holder" class="form-control">
+                    <option value="0">Choose...</option>
+                    <option value="1">Drizzle Season 2022</option>
+                    <option value="2">Chill Season 2022</option>
+                    <option value="3">Fresh Season 2023</option>
+                  </select>
+                </div>
+              </div>
+            </form>
             <br><br>
             <label style="color:black" class="fw-bold" for="season_catalog_level_holder">Catalog Level:</label>
             <input class="form-control season_catalog_level_holder d-inline-block w-auto" type="number" id="season_catalog_level_holder" min="0" max="100" value="0"/>

--- a/saveeditor.html
+++ b/saveeditor.html
@@ -90,14 +90,14 @@
             <label class="fw-bold" for="snail_holder">Snails:</label>
             <input class="form-control snail_holder d-inline-block w-auto" type="number" id="snail_holder" min="0" max="999" value="0"/>
             <br><br><br>
-			<label style="color:black" class="fw-bold" for="season_id_holder">Season:</label>
+            <label style="color:black" class="fw-bold" for="season_id_holder">Season:</label>
             <input class="form-control season_id_holder d-inline-block w-auto" type="number" id="season_id_holder" min="0" max="999" value="0"/>
-			<br><br>
-			<label style="color:black" class="fw-bold" for="season_catalog_level_holder">Catalog Level:</label>
+            <br><br>
+            <label style="color:black" class="fw-bold" for="season_catalog_level_holder">Catalog Level:</label>
             <input class="form-control season_catalog_level_holder d-inline-block w-auto" type="number" id="season_catalog_level_holder" min="0" max="100" value="0"/>
-			<label style="color:black" class="fw-bold" for="season_catalog_point_holder">Catalog Points:</label>
+            <label style="color:black" class="fw-bold" for="season_catalog_point_holder">Catalog Points:</label>
             <input class="form-control season_catalog_point_holder d-inline-block w-auto" type="number" id="season_catalog_point_holder" min="0" max="9500" value="0"/>
-			<br><br><br>
+            <br><br><br>
             <p class="fw-bold">Player Type:</p>
             <div id="image_gallery_playertype">
             <div class="image_gallery_playertype">

--- a/saveeditor.html
+++ b/saveeditor.html
@@ -89,7 +89,15 @@
             <img src="./assets/img/ui/snail.png" width="35" height="35" style="margin-bottom: 10px;">
             <label class="fw-bold" for="snail_holder">Snails:</label>
             <input class="form-control snail_holder d-inline-block w-auto" type="number" id="snail_holder" min="0" max="999" value="0"/>
-            <br>
+            <br><br><br>
+			<label style="color:black" class="fw-bold" for="season_id_holder">Season:</label>
+            <input class="form-control season_id_holder d-inline-block w-auto" type="number" id="season_id_holder" min="0" max="999" value="0"/>
+			<br><br>
+			<label style="color:black" class="fw-bold" for="season_catalog_level_holder">Catalog Level:</label>
+            <input class="form-control season_catalog_level_holder d-inline-block w-auto" type="number" id="season_catalog_level_holder" min="0" max="100" value="0"/>
+			<label style="color:black" class="fw-bold" for="season_catalog_point_holder">Catalog Points:</label>
+            <input class="form-control season_catalog_point_holder d-inline-block w-auto" type="number" id="season_catalog_point_holder" min="0" max="9500" value="0"/>
+			<br><br><br>
             <p class="fw-bold">Player Type:</p>
             <div id="image_gallery_playertype">
             <div class="image_gallery_playertype">

--- a/saveeditor.html
+++ b/saveeditor.html
@@ -92,7 +92,7 @@
             <br><br><br>
             <form>
               <div class="form-group row">
-                <label for="season_id_holder" class="col-sm-1 col-form-label fw-bold">Season:</label>
+                <label for="season_id_holder" class="col-sm-1 col-form-label fw-bold" style="color:black">Season:</label>
                 <div class="col-sm-3">
                   <select id="season_id_holder" class="form-control">
                     <option value="0">Choose...</option>
@@ -103,7 +103,7 @@
                 </div>
               </div>
             </form>
-            <br><br>
+            <br>
             <label style="color:black" class="fw-bold" for="season_catalog_level_holder">Catalog Level:</label>
             <input class="form-control season_catalog_level_holder d-inline-block w-auto" type="number" id="season_catalog_level_holder" min="0" max="100" value="0"/>
             <label style="color:black" class="fw-bold" for="season_catalog_point_holder">Catalog Points:</label>


### PR DESCRIPTION
This PR implements Season and Catalog Editors.

![Cap](https://github.com/Flexlion/flexlion.github.io/assets/27894534/6f1e0f80-8f43-436f-bb08-795f401f6b7d)

Details:
- The Forms are Located in the Player Settings.
- It fetch the values from the decrypted JSON save.
- Seasons can now be selected by their respective names instead of their ID number.
- Both Current and Unlocked Seasons IDs (Server/Client sections) are changed for consistency.
- The Catalog level and points have validations (Level 100 and 9500 Points respectively).

Notes:
This is partially working, as the changes are added to the default_edits array but the server doesn't accept the new contents. (Edit failed: Unknown edit type!)